### PR TITLE
Add session description

### DIFF
--- a/smart-oh-ws/src/main.py
+++ b/smart-oh-ws/src/main.py
@@ -19,7 +19,7 @@ logger = logging.getLogger("uvicorn.error")
 
 # Load configuration from environment variables
 ALLOWED_ORIGINS = os.getenv("ALLOWED_ORIGINS", "").split(",")
-ENV = os.getenv("ENV", "dev")
+ENV = os.getenv("ENV", "development")
 
 
 @asynccontextmanager
@@ -41,7 +41,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-manager = OfficeHourManager()
+manager = OfficeHourManager(dev=ENV == "development")
 
 
 @app.get("/")

--- a/smart-oh-ws/src/websocket/dummy_data.py
+++ b/smart-oh-ws/src/websocket/dummy_data.py
@@ -1,0 +1,76 @@
+import random
+
+from .state import TBoard, TCard, TColumn, User
+
+STUDENT_NAMES = [
+    "Alice Johnson",
+    "Bob Smith",
+    "Charlie Brown",
+    "David Wilson",
+    "Emma Davis",
+    "Fiona Garcia",
+    "George Martinez",
+    "Hannah Robinson",
+    "Ian Clark",
+    "Julia Lewis",
+    "Kevin Walker",
+    "Lily Hall",
+    "Michael Allen",
+    "Nina Young",
+    "Oscar King",
+    "Paula Wright",
+    "Quentin Scott",
+    "Rachel Adams",
+    "Sam Nelson",
+    "Tina Moore",
+]
+
+TA_NAMES = ["Dr. Anderson", "Ms. Baker", "Mr. Carter", "Prof. Daniels", "Dr. Evans"]
+
+
+def generate_dummy_data():
+    class_id = "class1"
+
+    students = [
+        TCard(
+            user=User(
+                id=f"student{j + 1}",
+                name=STUDENT_NAMES[j],
+                email=f"student{j + 1}@example.com",
+            ),
+            role="student",
+        )
+        for j in range(len(STUDENT_NAMES))
+    ]
+
+    tas = [
+        TCard(
+            user=User(
+                id=f"ta{k + 1}",
+                name=TA_NAMES[k],
+                email=f"ta{k + 1}@example.com",
+            ),
+            role="TA",
+        )
+        for k in range(len(TA_NAMES))
+    ]
+
+    # Assign 1 TA per session instead of 3
+    sessions = [
+        TColumn(
+            id=f"session{k + 1}",
+            title=f"Session {k + 1}",
+            cards=[random.choice(tas)],
+        )
+        for k in range(3)  # Fewer sessions
+    ]
+
+    return class_id, TBoard(
+        classId=class_id,
+        allUsers=students + tas,
+        columns=[
+            TColumn(id="queue", title="Queue", cards=students),
+            *sessions,
+            TColumn(id="session4", title="Session 4", cards=[]),
+        ],
+    )

--- a/smart-oh-ws/src/websocket/state.py
+++ b/smart-oh-ws/src/websocket/state.py
@@ -20,6 +20,7 @@ class TCard(BaseModel):
 class TColumn(BaseModel):
     id: str
     title: str
+    description: Optional[str] = None
     cards: List[TCard]
 
 

--- a/smart-oh-ws/src/websocket/websocket_manager.py
+++ b/smart-oh-ws/src/websocket/websocket_manager.py
@@ -4,13 +4,14 @@ from typing import Dict, List
 
 from fastapi import WebSocket
 
+from .dummy_data import generate_dummy_data
 from .state import TBoard
 
 logger = logging.getLogger("uvicorn.error")
 
 
 class OfficeHourManager:
-    def __init__(self):
+    def __init__(self, dev: bool = False):
         self.rooms: Dict[str, TBoard] = {}  # class_id -> TBoard
         self.connections: Dict[
             str, List[WebSocket]
@@ -18,6 +19,10 @@ class OfficeHourManager:
 
         self.lock = asyncio.Lock()
         self.cleanup_task = None
+
+        if dev:
+            class_id, board = generate_dummy_data()
+            self.rooms[class_id] = board
 
     def get_or_create_room(self, class_id: str) -> TBoard:
         if class_id not in self.rooms:

--- a/smart-oh/src/components/office-hour-room/EditableDescription.tsx
+++ b/smart-oh/src/components/office-hour-room/EditableDescription.tsx
@@ -1,0 +1,118 @@
+import { Textarea } from "@/components/ui/textarea";
+import { Pencil } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+const urlRegex = /(https?:\/\/[^\s]+)/g;
+
+type EditableDescriptionProps = {
+    description?: string;
+    onDescriptionChange: (newDescription: string) => void;
+    isEditable?: boolean;
+    placeholder?: string;
+};
+
+export function EditableDescription({
+    description,
+    onDescriptionChange,
+    isEditable = true,
+    placeholder = "Enter session details..."
+}: EditableDescriptionProps) {
+    const [isEditing, setIsEditing] = useState(false);
+    const [newDescription, setNewDescription] = useState(description ?? "");
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+    useEffect(() => {
+        setNewDescription(description ?? "");
+    }, [description]);
+
+    function handleDoubleClick() {
+        if (!isEditable) return;
+        setIsEditing(true);
+        setTimeout(() => textareaRef.current?.focus(), 0);
+    }
+
+    function handleBlur() {
+        setIsEditing(false);
+        if (newDescription.trim() !== "") {
+            onDescriptionChange(newDescription.trim());
+        } else {
+            setNewDescription(""); // Ensure empty input remains empty
+            onDescriptionChange(""); // Pass an empty string instead of undefined
+        }
+    }
+
+    function handleKeyDown(e: React.KeyboardEvent) {
+        if (e.key === "Enter" && !e.shiftKey) {
+            e.preventDefault();
+            handleBlur();
+        }
+    }
+
+    function renderDescription(text: string) {
+        return text.split(urlRegex).map((part, index) =>
+            urlRegex.test(part) ? (
+                <a
+                    key={index}
+                    href={part}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary font-medium text-blue-600 dark:text-blue-400 hover:underline break-all"
+                >
+                    {part}
+                </a>
+            ) : (
+                <span key={index} className="break-words">
+                    {part}
+                </span>
+            )
+        );
+    }
+
+    return (
+        <div
+            className={`relative group text-sm text-muted-foreground ${
+                isEditable ? "cursor-pointer" : ""
+            } w-full`}
+            onDoubleClick={handleDoubleClick}
+        >
+            {isEditing ? (
+                <Textarea
+                    ref={textareaRef}
+                    value={newDescription}
+                    onChange={(e) => setNewDescription(e.target.value)}
+                    onBlur={handleBlur}
+                    onKeyDown={handleKeyDown}
+                    className="border rounded p-2 focus:ring-2 w-full"
+                />
+            ) : (
+                <div className="w-full">
+                    {newDescription.trim() !== "" ? (
+                        <div className="w-full inline">
+                            <span className="whitespace-pre-wrap break-words">
+                                {renderDescription(newDescription)}
+                            </span>
+                            {isEditable && (
+                                <Pencil
+                                    className="w-4 h-4 ml-1 opacity-0 group-hover:opacity-50 transition-opacity cursor-pointer inline align-text-bottom"
+                                    onClick={handleDoubleClick}
+                                />
+                            )}
+                        </div>
+                    ) : (
+                        <div className="inline-flex items-center">
+                            <span className="italic text-muted-foreground">
+                                {placeholder}
+                            </span>
+                            {isEditable && (
+                                <Pencil
+                                    className="w-4 h-4 ml-1 opacity-0 group-hover:opacity-50 transition-opacity cursor-pointer inline-block align-text-bottom"
+                                    onClick={handleDoubleClick}
+                                />
+                            )}
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/smart-oh/src/components/office-hour-room/board.tsx
+++ b/smart-oh/src/components/office-hour-room/board.tsx
@@ -478,6 +478,19 @@ export function Board({
         handleRoomStateChange({ ...data, columns: newColumns });
     }
 
+    function handleEditColumnDescription(
+        columnId: string,
+        newDescription: string
+    ) {
+        const newColumns = data.columns.map((column) =>
+            column.id === columnId
+                ? { ...column, description: newDescription }
+                : column
+        );
+
+        handleRoomStateChange({ ...data, columns: newColumns });
+    }
+
     function handleJoinColumn(columnId: string) {
         const newAllUsers = data.allUsers.map((card) =>
             card.user.id === user.id
@@ -556,6 +569,7 @@ export function Board({
                         userCurrentColumnId={userCurrentColumnId}
                         onRemoveColumn={handleRemoveColumn}
                         onEditColumnTitle={handleEditColumnTitle}
+                        onEditColumnDescription={handleEditColumnDescription}
                         onJoinColumn={handleJoinColumn}
                         onLeaveColumn={handleLeaveColumn}
                     />

--- a/smart-oh/src/components/office-hour-room/column.tsx
+++ b/smart-oh/src/components/office-hour-room/column.tsx
@@ -17,6 +17,7 @@ import { memo, useContext, useEffect, useRef, useState } from "react";
 import invariant from "tiny-invariant";
 
 import { Button } from "../ui/button";
+import { EditableDescription } from "./EditableDescription";
 import { Card, CardShadow } from "./card";
 import {
     TCardData,
@@ -85,6 +86,7 @@ export function Column({
     userCurrentColumnId,
     onRemoveColumn,
     onEditColumnTitle,
+    onEditColumnDescription,
     onJoinColumn,
     onLeaveColumn
 }: {
@@ -92,6 +94,7 @@ export function Column({
     userCurrentColumnId?: string;
     onRemoveColumn: (columnId: string) => void;
     onEditColumnTitle: (columnId: string, newTitle: string) => void;
+    onEditColumnDescription: (columnId: string, newDescription: string) => void;
     onJoinColumn: (columnId: string) => void;
     onLeaveColumn: (columnId: string, userId: string) => void;
 }) {
@@ -250,7 +253,7 @@ export function Column({
                 {...{ [blockBoardPanningAttr]: true }}
             >
                 <div
-                    className="flex flex-row items-center justify-between p-3"
+                    className="flex flex-row items-center justify-between p-3 pb-0"
                     ref={headerRef}
                 >
                     <EditableTitle
@@ -284,6 +287,21 @@ export function Column({
                         </DropdownMenu>
                     )}
                 </div>
+                <div className="flex flex-col px-3 pb-3">
+                    {column.id !== "queue" && (
+                        <EditableDescription
+                            description={column?.description}
+                            onDescriptionChange={(newDescription) =>
+                                onEditColumnDescription(
+                                    column.id,
+                                    newDescription
+                                )
+                            }
+                            isEditable={activeRole !== "student"}
+                        />
+                    )}
+                </div>
+
                 <div
                     className="flex flex-col pb-2 overflow-y-auto [overflow-anchor:none] [scrollbar-color:theme(colors.slate.600)_theme(colors.slate.700)] [scrollbar-width:thin] "
                     ref={scrollableRef}

--- a/smart-oh/src/components/office-hour-room/data.ts
+++ b/smart-oh/src/components/office-hour-room/data.ts
@@ -8,6 +8,7 @@ export type TCard = {
 export type TColumn = {
   id: string;
   title: string;
+  description?: string;
   cards: TCard[];
 };
 

--- a/smart-oh/src/components/office-hour-room/editable-title.tsx
+++ b/smart-oh/src/components/office-hour-room/editable-title.tsx
@@ -1,5 +1,5 @@
 import { Pencil } from "lucide-react";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { Input } from "../ui/input";
 
@@ -17,6 +17,10 @@ export function EditableTitle({
     const [isEditing, setIsEditing] = useState(false);
     const [newTitle, setNewTitle] = useState(title);
     const inputRef = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+        setNewTitle(title);
+    }, [title]);
 
     function handleDoubleClick() {
         if (!isEditable) return;
@@ -55,7 +59,7 @@ export function EditableTitle({
                 />
             ) : (
                 <div className="flex items-center gap-1">
-                    {title}
+                    {newTitle}
                     {isEditable && (
                         <Pencil
                             className="w-4 h-4 opacity-0 group-hover:opacity-50 transition-opacity"


### PR DESCRIPTION
This PR addresses #20 along with additional features.
1. Editable session description similar to session title, ensure that links are clickable for end users.
    <img width="331" alt="image" src="https://github.com/user-attachments/assets/1fa57e5f-8454-4e11-a724-ce60b3543094" />

2. Create dummy data creation for class ID `class1` when `ENV=development` in the websocket server. 
3. Improved local state handling when updating session title and description. Local state updates first to reflect changes immediately, and a `useEffect` function rerenders the texts after data comes back from the ws server.
